### PR TITLE
Patch qy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2019-10-22
+resolve.symlinks置为false，避免通过npm link安装的包的依赖解析问题
+
 # 2019-10-15
 
 添加rishiqingSingleSpa项目初始化配置

--- a/assets/kite-design-func-color.css
+++ b/assets/kite-design-func-color.css
@@ -1,0 +1,6 @@
+:root {
+  --kite-func-color-link: #2B88FE;
+  --kite-func-color-success: #51C419;
+  --kite-func-color-warn: #51C419;
+  --kite-func-color-error: #F5222D;
+}

--- a/assets/kite-design-func-color.css
+++ b/assets/kite-design-func-color.css
@@ -1,6 +1,6 @@
 :root {
   --kite-func-color-link: #2B88FE;
   --kite-func-color-success: #51C419;
-  --kite-func-color-warn: #51C419;
+  --kite-func-color-warn: #FAAD15;
   --kite-func-color-error: #F5222D;
 }

--- a/assets/normalize.css
+++ b/assets/normalize.css
@@ -11,6 +11,9 @@
 html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
+
+  font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Helvetica,PingFang SC,Hiragino Sans GB,Noto Sans,Noto Sans CJK SC,Microsoft YaHei,微软雅黑,SimSun,sans-serif;
+  color: #333333;
 }
 
 /* Sections

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ module.exports = (api, projectOptions) => {
           .entry('app')
           .prepend(path.resolve(__dirname, './assets/normalize.css'))
           .prepend(path.resolve(__dirname, './assets/kite-design-theme-color.css'))
+          .prepend(path.resolve(__dirname, './assets/kite-design-func-color.css'))
           .end()
       }
 

--- a/index.js
+++ b/index.js
@@ -69,6 +69,11 @@ module.exports = (api, projectOptions) => {
       // kite-design 里会依赖 r-request
       .set('r-request', path.resolve(__dirname, './lib/r-request.js'))
 
+    // 把 resolve.symlinks置为false, 这样可以避免很多npm link安装的包，在找文件的时候的错误
+    webpackConfig
+      .resolve
+      .set('symlinks', false)
+
     // 处理 scss 代码
     Scss(api, webpackConfig)
 

--- a/index.js
+++ b/index.js
@@ -96,8 +96,8 @@ module.exports = (api, projectOptions) => {
     // 处理 scss 代码
     Scss(api, webpackConfig)
 
-    // `调试账户选择`功能所需的脚本
     if (process.env.NODE_ENV === 'development') {
+      // `调试账户选择`功能所需的脚本
       if (pluginConfig.enableDevAccountSel) {
         webpackConfig
           .entry('app')
@@ -106,14 +106,13 @@ module.exports = (api, projectOptions) => {
       }
 
       if (pluginConfig.rishiqingSingleSpa) {
+        // 添加css变量 & 浏览器样式初始化
         webpackConfig
           .entry('app')
           .prepend(path.resolve(__dirname, './assets/normalize.css'))
           .prepend(path.resolve(__dirname, './assets/kite-design-theme-color.css'))
           .prepend(path.resolve(__dirname, './assets/kite-design-func-color.css'))
           .end()
-
-        types.forEach(type => addPostcssCustomProperties(webpackConfig.module.rule('scss').oneOf(type).use('postcss-loader')))
       }
 
       // 读取 rsq-dev-account.json 中设置的账号服务器信息
@@ -135,6 +134,10 @@ module.exports = (api, projectOptions) => {
           }
         })
       })
+    }
+
+    if (pluginConfig.rishiqingSingleSpa) {
+      types.forEach(type => addPostcssCustomProperties(webpackConfig.module.rule('scss').oneOf(type).use('postcss-loader')))
     }
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -506,7 +506,6 @@
       "version": "3.2.1",
       "resolved": "http://registry.npm.taobao.org/ansi-styles/download/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1038,7 +1037,6 @@
       "version": "2.4.2",
       "resolved": "http://registry.npm.taobao.org/chalk/download/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1239,7 +1237,6 @@
       "version": "1.9.3",
       "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1247,8 +1244,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "http://registry.npm.taobao.org/color-name/download/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -1820,8 +1816,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "http://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.3.3",
@@ -3225,8 +3220,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "http://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -3519,6 +3513,11 @@
       "resolved": "http://registry.npm.taobao.org/iota-array/download/iota-array-1.0.0.tgz",
       "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
     },
+    "ip-regex": {
+      "version": "4.1.0",
+      "resolved": "https://npm.timetask.cn/ip-regex/-/ip-regex-4.1.0.tgz",
+      "integrity": "sha1-WtYvaFoU7bQhq+vC//jblN9ntFU="
+    },
     "is-accessor-descriptor": {
       "version": "0.1.6",
       "resolved": "http://registry.npm.taobao.org/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
@@ -3756,6 +3755,14 @@
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/is-typedarray/download/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-url-superb": {
+      "version": "3.0.0",
+      "resolved": "https://npm.timetask.cn/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "integrity": "sha1-uaHah4oaxzZZBH0eb07yLCCdPiU=",
+      "requires": {
+        "url-regex": "^5.0.0"
+      }
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -4956,6 +4963,64 @@
       "resolved": "http://registry.npm.taobao.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
+    "postcss": {
+      "version": "7.0.21",
+      "resolved": "https://npm.timetask.cn/postcss/-/postcss-7.0.21.tgz",
+      "integrity": "sha1-BrsHgkwZwgIcXQVtWxDDW5iffhc=",
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://npm.timetask.cn/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://npm.timetask.cn/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-custom-properties": {
+      "version": "9.0.2",
+      "resolved": "https://npm.timetask.cn/postcss-custom-properties/-/postcss-custom-properties-9.0.2.tgz",
+      "integrity": "sha1-CRrvqjCYJjAtU+xteA++Hfj0D9Q=",
+      "requires": {
+        "postcss": "^7.0.17",
+        "postcss-values-parser": "^3.0.5"
+      }
+    },
+    "postcss-values-parser": {
+      "version": "3.0.5",
+      "resolved": "https://npm.timetask.cn/postcss-values-parser/-/postcss-values-parser-3.0.5.tgz",
+      "integrity": "sha1-n4OEn7ieqsdMLVv3Xo6XFVCKjI0=",
+      "requires": {
+        "color-name": "^1.1.4",
+        "is-number": "^7.0.0",
+        "is-url-superb": "^3.0.0",
+        "postcss": "^7.0.5",
+        "url-regex": "^5.0.0"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://npm.timetask.cn/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://npm.timetask.cn/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "http://registry.npm.taobao.org/prelude-ls/download/prelude-ls-1.1.2.tgz",
@@ -6020,7 +6085,6 @@
       "version": "5.5.0",
       "resolved": "http://registry.npm.taobao.org/supports-color/download/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -6141,6 +6205,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tlds": {
+      "version": "1.203.1",
+      "resolved": "https://npm.timetask.cn/tlds/-/tlds-1.203.1.tgz",
+      "integrity": "sha1-TcmwL1PeMxW8mLgGZeE94+38Hfw="
     },
     "tmp": {
       "version": "0.0.33",
@@ -6424,6 +6493,15 @@
           "resolved": "http://registry.npm.taobao.org/punycode/download/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
+      }
+    },
+    "url-regex": {
+      "version": "5.0.0",
+      "resolved": "https://npm.timetask.cn/url-regex/-/url-regex-5.0.0.tgz",
+      "integrity": "sha1-j1RWq4PYmNGLL5F1OnAmSbhzJzo=",
+      "requires": {
+        "ip-regex": "^4.1.0",
+        "tlds": "^1.203.0"
       }
     },
     "use": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-rishiqing",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "license": "MIT",
   "dependencies": {
     "@rishiqing/webpack-system-register": "^1.6.0",
-    "case-sensitive-paths-webpack-plugin": "^2.2.0",
     "memory-fs": "^0.4.1",
+    "postcss-custom-properties": "^9.0.2",
     "require-all": "^3.0.0",
     "webpack": "^4.29.2",
     "webpack-spritesmith": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cli-plugin-rishiqing",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "vue-cli 3.0 plugin for rishiqing",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
resolve.symlinks设置为false

添加功能色css变量

在assets/normalize.css里添加默认字体

去掉 case-sensitive-paths-webpack-plugin 插件

添加一个 postcss插件：postcss-custom-properties，用于生成css变量的默认值，如果浏览器不支持css变量，则可以fallback到默认值