### PR TITLE
log--添加按需引用kite-design的配置

### DIFF
--- a/doc/RISHIQING_SINGLE_SPA.md
+++ b/doc/RISHIQING_SINGLE_SPA.md
@@ -183,4 +183,13 @@ webpackConfig.plugins.push(new WebpackSystemRegister({
 `ROUTER_BASE`，字符串，表示项目的地址前缀，主要用在router.js里的base
 
 
+##### kite-design的按需引用
+引入了[babel-plugin-import](https://github.com/ant-design/babel-plugin-import)可以更方便的实现按需加载组件，
+也实现了组件css文件的自动按需引用，从而减少文件体积，使项目构建打包更加快速。
+
+这个babel插件相关的配置已经写入到了工程根目录下的`babel.config.js`文件中。并且在`main.js`写了如何按需应用的例子。
+
+:::tip
+  更多`kite-design`组件按需引用的相关内容和使用方式，请移步到[kite-design](https://kite-design.rishiqing.com/)
+:::
 

--- a/generator/index.js
+++ b/generator/index.js
@@ -2,7 +2,7 @@
 * @Author: qinyang
 * @Date:   2018-07-21 16:46:58
  * @Last Modified by: qile
- * @Last Modified time: 2019-11-28 13:42:15
+ * @Last Modified time: 2019-11-29 11:56:07
 */
 
 // 这是 https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-eslint/eslintOptions.js
@@ -59,9 +59,6 @@ module.exports = (api, options, rootOptions) => {
   // 基础 babel.config.js 参数设置
   api.extendPackage({
     babel: {
-      presets: [
-        '@vue/app',
-      ],
       plugins : [
         ['import',
           {

--- a/generator/index.js
+++ b/generator/index.js
@@ -1,8 +1,8 @@
 /*
 * @Author: qinyang
 * @Date:   2018-07-21 16:46:58
- * @Last Modified by: TimZhang
- * @Last Modified time: 2019-02-02 10:03:56
+ * @Last Modified by: qile
+ * @Last Modified time: 2019-11-27 22:42:10
 */
 
 // 这是 https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-eslint/eslintOptions.js
@@ -32,6 +32,8 @@ module.exports = (api, options, rootOptions) => {
       'rishiqing-deploy': '^2.0.9',
       'sass-resources-loader': '^1.3.3',
       'resolve-url-loader': '^2.3.0',
+      "babel-plugin-import": "^1.13.0",
+      "worker-loader": "^2.0.0",
     },
   })
 
@@ -51,6 +53,24 @@ module.exports = (api, options, rootOptions) => {
       },
       // 将lib文件夹下的代码进行babel转化——modify cwp
       transpileDependencies: ['vue-cli-plugin-rishiqing'],
+    },
+  })
+
+  // 基础 babel.config.js 参数设置
+  api.extendPackage({
+    babel: {
+      presets: [
+        '@vue/app',
+      ],
+      plugins : [
+        ['import',
+          {
+            libraryName: '@rishiqing/kite-design',
+            libraryDirectory: 'lib/components',
+            style: name => `${name}/style.css`,
+          },
+        ],
+      ]
     },
   })
 
@@ -127,7 +147,7 @@ module.exports = (api, options, rootOptions) => {
     api.extendPackage({
       dependencies: {
         // 这个地方，引入第三方库的版本不能直接写 latest，不然无法正常添加到dependencies
-        '@rishiqing/kite-design': '^0.0.35',
+        '@rishiqing/kite-design': '^0.0.38-viii.6499',
         // '@rishiqing/sdk': '0.0.1',
         // 'vue-rx': '^6.2.0',
         axios: '^0.19.0',
@@ -158,7 +178,6 @@ module.exports = (api, options, rootOptions) => {
       api.injectRootOptions('src/singleSpa.js', 'i18n,')
     }
   }
-
   // .eslintrc.js 配置
   const eslintGlobals = {
     // 默认把__DEV__加进去

--- a/generator/index.js
+++ b/generator/index.js
@@ -2,7 +2,7 @@
 * @Author: qinyang
 * @Date:   2018-07-21 16:46:58
  * @Last Modified by: qile
- * @Last Modified time: 2019-11-29 11:56:07
+ * @Last Modified time: 2019-11-29 16:03:36
 */
 
 // 这是 https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-eslint/eslintOptions.js
@@ -144,7 +144,7 @@ module.exports = (api, options, rootOptions) => {
     api.extendPackage({
       dependencies: {
         // 这个地方，引入第三方库的版本不能直接写 latest，不然无法正常添加到dependencies
-        '@rishiqing/kite-design': '0.0.38-viii.6499',
+        '@rishiqing/kite-design': '^0.0.38-viii.6499',
         // '@rishiqing/sdk': '0.0.1',
         // 'vue-rx': '^6.2.0',
         axios: '^0.19.0',

--- a/generator/index.js
+++ b/generator/index.js
@@ -2,7 +2,7 @@
 * @Author: qinyang
 * @Date:   2018-07-21 16:46:58
  * @Last Modified by: qile
- * @Last Modified time: 2019-11-27 22:42:10
+ * @Last Modified time: 2019-11-28 13:42:15
 */
 
 // 这是 https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-eslint/eslintOptions.js
@@ -147,7 +147,7 @@ module.exports = (api, options, rootOptions) => {
     api.extendPackage({
       dependencies: {
         // 这个地方，引入第三方库的版本不能直接写 latest，不然无法正常添加到dependencies
-        '@rishiqing/kite-design': '^0.0.38-viii.6499',
+        '@rishiqing/kite-design': '0.0.38-viii.6499',
         // '@rishiqing/sdk': '0.0.1',
         // 'vue-rx': '^6.2.0',
         axios: '^0.19.0',

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -1,21 +1,18 @@
 import Vue from 'vue'
 // import VurRx from 'vue-rx'
-import KiteBasic from '@rishiqing/kite-design/dist/kite-basic'
-import KiteBusiness from '@rishiqing/kite-design/dist/kite-business'
+// 按需引入kite-design组件
+import { Button } from '@rishiqing/kite-design'
+import '@rishiqing/kite-design/lib/style/utils.css'
+
 import App from './App.vue'
 import router from './router'
 import store from './store'
 
-import '@rishiqing/kite-design/dist/kite-basic.css'
-import '@rishiqing/kite-design/dist/kite-business.css'
 
 export * from './singleSpa'
 
-if (!RISHIQING_SINGLE_SPA) {
-  // Vue.use(VurRx)
-  Vue.use(KiteBasic)
-  Vue.use(KiteBusiness)
-}
+// Vue.use(VurRx)
+Vue.use(Button)
 
 Vue.config.productionTip = false
 

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -1,8 +1,12 @@
 import Vue from 'vue'
 // import VurRx from 'vue-rx'
 
-// 按需引入kite-design组件
-import { Button } from '@rishiqing/kite-design'
+// kite-basic基础组件
+import KiteBasic from '@rishiqing/kite-design/lib/src/kite-basic'
+// kite-basic业务组件按需引用
+import {Emoji} from '@rishiqing/kite-design/lib/src/kite-basic'
+// 样式代码
+import '@rishiqing/kite-design/lib/src/style'
 // kite的工具类css
 import '@rishiqing/kite-design/lib/style/utils.css'
 
@@ -14,7 +18,8 @@ import store from './store'
 export * from './singleSpa'
 
 // Vue.use(VurRx)
-Vue.use(Button)
+Vue.use(KiteBasic)
+Vue.use(Emoji)
 
 Vue.config.productionTip = false
 

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -4,7 +4,7 @@ import Vue from 'vue'
 // kite-basic基础组件
 import KiteBasic from '@rishiqing/kite-design/lib/src/kite-basic'
 // kite-basic业务组件按需引用
-import {Emoji} from '@rishiqing/kite-design/lib/src/kite-basic'
+import {DatePicker} from '@rishiqing/kite-design/lib/src/kite-basic'
 // 样式代码
 import '@rishiqing/kite-design/lib/src/style'
 // kite的工具类css
@@ -19,7 +19,7 @@ export * from './singleSpa'
 
 // Vue.use(VurRx)
 Vue.use(KiteBasic)
-Vue.use(Emoji)
+Vue.use(DatePicker)
 
 Vue.config.productionTip = false
 

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -3,8 +3,10 @@ import Vue from 'vue'
 
 // kite-basic基础组件
 import KiteBasic from '@rishiqing/kite-design/lib/src/kite-basic'
-// kite-basic业务组件按需引用
-import {Emoji} from '@rishiqing/kite-design'
+
+// 如果需要按需引用 kite 的业务组件，可以参考这种写法
+// import { Emoji } from '@rishiqing/kite-design'
+
 // 样式代码
 import '@rishiqing/kite-design/lib/src/style'
 // kite的工具类css
@@ -19,7 +21,7 @@ export * from './singleSpa'
 
 // Vue.use(VurRx)
 Vue.use(KiteBasic)
-Vue.use(Emoji)
+// Vue.use(Emoji)
 
 Vue.config.productionTip = false
 

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -4,7 +4,7 @@ import Vue from 'vue'
 // kite-basic基础组件
 import KiteBasic from '@rishiqing/kite-design/lib/src/kite-basic'
 // kite-basic业务组件按需引用
-import {DatePicker} from '@rishiqing/kite-design/lib/src/kite-basic'
+import {Emoji} from '@rishiqing/kite-design'
 // 样式代码
 import '@rishiqing/kite-design/lib/src/style'
 // kite的工具类css
@@ -19,7 +19,7 @@ export * from './singleSpa'
 
 // Vue.use(VurRx)
 Vue.use(KiteBasic)
-Vue.use(DatePicker)
+Vue.use(Emoji)
 
 Vue.config.productionTip = false
 

--- a/generator/rishiqingSingleSpa/src/main.js
+++ b/generator/rishiqingSingleSpa/src/main.js
@@ -1,7 +1,9 @@
 import Vue from 'vue'
 // import VurRx from 'vue-rx'
+
 // 按需引入kite-design组件
 import { Button } from '@rishiqing/kite-design'
+// kite的工具类css
 import '@rishiqing/kite-design/lib/style/utils.css'
 
 import App from './App.vue'

--- a/generator/rishiqingSingleSpa/src/router.js
+++ b/generator/rishiqingSingleSpa/src/router.js
@@ -3,9 +3,7 @@ import Router from 'vue-router'
 import Home from './views/Home.vue'
 import About from './views/About.vue'
 
-if (!RISHIQING_SINGLE_SPA) {
-  Vue.use(Router)
-}
+Vue.use(Router)
 
 export default new Router({
   mode: 'history',

--- a/generator/rishiqingSingleSpa/src/store.js
+++ b/generator/rishiqingSingleSpa/src/store.js
@@ -1,9 +1,7 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 
-if (!RISHIQING_SINGLE_SPA) {
-  Vue.use(Vuex)
-}
+Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1014,11 +1014,6 @@
       "resolved": "http://registry.npm.taobao.org/camelcase/download/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
-    "case-sensitive-paths-webpack-plugin": {
-      "version": "2.2.0",
-      "resolved": "http://registry.npm.taobao.org/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.2.0.tgz",
-      "integrity": "sha1-M3HvY2XvnCX6S4HBas4OnH3FjD4="
-    },
     "caseless": {
       "version": "0.12.0",
       "resolved": "http://registry.npm.taobao.org/caseless/download/caseless-0.12.0.tgz",
@@ -2531,7 +2526,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2549,11 +2545,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2566,15 +2564,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2677,7 +2678,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2687,6 +2689,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2699,17 +2702,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2726,6 +2732,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2798,7 +2805,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2808,6 +2816,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2883,7 +2892,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2913,6 +2923,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2930,6 +2941,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2968,11 +2980,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/prompts.js
+++ b/prompts.js
@@ -1,8 +1,8 @@
 /*
 * @Author: qinyang
 * @Date:   2018-07-21 22:15:42
- * @Last Modified by: TimZhang
- * @Last Modified time: 2019-02-02 10:19:30
+ * @Last Modified by: qile
+ * @Last Modified time: 2019-11-27 22:13:46
 */
 const path = require('path')
 
@@ -19,7 +19,7 @@ module.exports = [
     // 需要预置哪些代码块
     name: 'presetCodeList',
     message: '请选择需要预置的代码块',
-    default: ['init', 'constants', 'services', 'devAccountSel'],
+    default: ['init', 'constants', 'services', 'devAccountSel',],
     choices: [
       {
         name: '初始化配置',

--- a/singleSpaConfig.js
+++ b/singleSpaConfig.js
@@ -42,11 +42,13 @@ module.exports = function singleSpaConfig(api) {
       //   callback()
       // },
     ]
-
     webpackConfig.plugins.push(new WebpackSystemRegister({
       systemjsDeps: [
         /^share-data/,
       ],
     }))
+
+    // 如果在Webpack中使用System global构建代码，需要以下配置来避免重写:
+    webpackConfig.module.rules.push({ parser: { system: false } })
   })
 }

--- a/singleSpaConfig.js
+++ b/singleSpaConfig.js
@@ -48,7 +48,11 @@ module.exports = function singleSpaConfig(api) {
       ],
     }))
 
-    // 如果在Webpack中使用System global构建代码，需要以下配置来避免重写:
+    /**
+     * 由于webpack在内部也引入了System.js，但我们在项目中使用System.import()的时候
+     * 需要使用自己主工程引入的System.js，因此此处需要将webpack中的system配置为false。
+     */
+
     webpackConfig.module.rules.push({ parser: { system: false } })
   })
 }


### PR DESCRIPTION
### 自我检查
- [x] 标题已用`log--`进行汇总(多项之间用`&`进行连接)
- [x] 无明显bug
- [x] 模块引用路径已确认(`大小写问题`)

### 自查代码格式(eslint有很多检查不到的，这里会列一些我们经常犯的)
- [x] import对齐(凡是你修改到的文件，如果发现import没对齐，请对齐一下)
- [x] 无大块函数

### 注意事项
- 引用了新的第三方包:
worker-loader 
babel-plugin-import

### 对本次pr的详细描述
-本次pr主要是添加了babel-plugin-import这个插件来方便，按需引用kite-design组件。

### 想对代码审查者说的话
- love&peace

- [x] 完成代码审查
